### PR TITLE
refactor: unify AIL & Lacus Docker orchestration, docs, and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ doc/data-flow.png
 doc/ail_queues.dot
 doc/ail_queues.svg
 doc/statistics
+data/screenshots/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.PHONY: help start-all stop-all restart-all status-all logs-all lacus-up lacus-down ail-up ail-down
+
+help:
+    @echo "Available targets:"
+    @echo "  start-all         - Start all AIL and Lacus containers (cross-platform)"
+    @echo "  stop-all          - Stop all AIL and Lacus containers"
+    @echo "  restart-all       - Restart all AIL and Lacus containers"
+    @echo "  status-all        - Show status of all AIL and Lacus containers"
+    @echo "  logs-all [svc]    - Show logs for a specific service or list available services"
+    @echo "  lacus-up          - Start only Lacus containers"
+    @echo "  lacus-down        - Stop only Lacus containers"
+    @echo "  ail-up            - Start only AIL containers"
+    @echo "  ail-down          - Stop only AIL containers"
+
+# Cross-platform orchestration (uses PowerShell or Bash depending on OS)
+start-all:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 up ; \
+    else \
+        bash scripts/start-all.sh up ; \
+    fi
+
+stop-all:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 down ; \
+    else \
+        bash scripts/start-all.sh down ; \
+    fi
+
+restart-all:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 restart ; \
+    else \
+        bash scripts/start-all.sh restart ; \
+    fi
+
+status-all:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 status ; \
+    else \
+        bash scripts/start-all.sh status ; \
+    fi
+
+logs-all:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 logs $(svc) ; \
+    else \
+        bash scripts/start-all.sh logs $(svc) ; \
+    fi
+
+lacus-up:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 lacus-only up ; \
+    else \
+        bash scripts/start-all.sh lacus-only up ; \
+    fi
+
+lacus-down:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 lacus-only down ; \
+    else \
+        bash scripts/start-all.sh lacus-only down ; \
+    fi
+
+ail-up:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 ail-only up ; \
+    else \
+        bash scripts/start-all.sh ail-only up ; \
+    fi
+
+ail-down:
+    @if [ "$(OS)" = "Windows_NT" ]; then \
+        pwsh -ExecutionPolicy Bypass -File scripts/start-all.ps1 ail-only down ; \
+    else \
+        bash scripts/start-all.sh ail-only down ; \
+    fi

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,9 +1,11 @@
-# AIL Framework - Docker Containerization 🐳
 
-This repository contains a **complete and verified working** containerized setup for the AIL (Analysis Information Leak) Framework with full web crawler functionality, local development support, and deployment guidance.
+# AIL Framework - Unified Docker Orchestration 🐳
 
-## ✅ **STATUS: FULLY OPERATIONAL** 
-- **Container Infrastructure**: All 7 services running ✅
+This repository provides a **complete, scalable, and modular containerized setup** for the AIL (Analysis Information Leak) Framework, including the Lacus web crawler as a separate, independently managed service. This README is your high-level starting point—see [`docs/docker.md`](docs/docker.md) for full details and advanced usage.
+
+
+## ✅ **STATUS: FULLY OPERATIONAL**
+- **Container Infrastructure**: All core and crawler services running ✅
 - **Web Crawler**: End-to-end submission and processing verified ✅
 - **Database Connectivity**: Redis, Kvrocks, Valkey all connected ✅
 - **Web Interface**: Login, dashboard, and crawler UI working ✅
@@ -11,12 +13,13 @@ This repository contains a **complete and verified working** containerized setup
 
 ---
 
+
 ## 🏗️ Architecture Overview
 
 ```
 AIL Docker Stack
 ├── ail-app (Port 7000)          # Main AIL application with Flask UI
-├── lacus (Port 7100)            # Web crawler service  
+├── lacus (Port 7100)            # Web crawler service (runs as a separate, modular stack)
 ├── redis-cache (6379)           # Core caching and operations
 ├── redis-log (6380)             # Logging and debugging
 ├── redis-work (6381)            # Work queues and job processing
@@ -24,6 +27,8 @@ AIL Docker Stack
 ├── valkey (6385)                # Lacus crawler backend
 └── tor_proxy                    # Tor proxy for .onion crawling
 ```
+
+> **Note:** The Lacus crawler and its dependencies are orchestrated via a separate Docker Compose file for modularity and scalability. You can start/stop Lacus independently, scale it separately, or even run it on different infrastructure if needed. See below for orchestration commands.
 
 ### 🔄 **Data Flow Architecture**
 ```
@@ -52,6 +57,7 @@ The AIL framework uses **three different Redis-compatible databases** for optima
 
 ---
 
+
 ## 🚀 Quick Start Guide
 
 ### Prerequisites
@@ -62,7 +68,7 @@ The AIL framework uses **three different Redis-compatible databases** for optima
 
 ### 1. Clone Repository
 ```powershell
-git clone https://github.com/ail-project/ail-framework.git ail-framework
+git clone https://github.com/YRSzMm32YCEdUwgUOBks/AIL-framework.git ail-framework
 cd ail-framework
 ```
 
@@ -78,283 +84,165 @@ This downloads essential components:
 
 **Without this step, the tracker functionality will fail with internal server errors.**
 
-### 3. Launch AIL Stack
+### 3. Orchestration: Start All Services
+
+#### **Recommended: Use the Makefile (cross-platform)**
+
 ```powershell
-# Build and start all services (first time)
-docker-compose up --build -d
+# Start all AIL and Lacus services (auto-detects your OS)
+make start-all
+
+# Stop all services
+make stop-all
+
+# Restart all services
+make restart-all
 
 # Check status
-docker-compose ps
+make status
 ```
 
-### 4. Verify Setup ✅
-```powershell
-# Wait for services to initialize (2-3 minutes)
-Start-Sleep 180
+#### **Or: Use the orchestration scripts directly**
 
-# Check if AIL is responding
-curl http://localhost:7000/api/v1/health
+- **Windows/PowerShell:**
+  ```powershell
+  scripts/start-all.ps1 up
+  scripts/start-all.ps1 down
+  scripts/start-all.ps1 status
+  ```
+- **Linux/macOS/Bash:**
+  ```bash
+  ./scripts/start-all.sh up
+  ./scripts/start-all.sh down
+  ./scripts/start-all.sh status
+  ```
 
-# Check container status
-docker-compose logs ail-app --tail=50
+#### **Manual Docker Compose (Advanced/Optional)**
+
+```bash
+# Create the shared network (if not already present)
+docker network create ail-net --driver bridge
+
+# Start Lacus services (separate stack)
+docker-compose -f docker-compose.lacus.yml up -d
+
+# Start AIL services
+docker-compose -f docker-compose.yml up -d
+
+# Stop services (reverse order)
+docker-compose -f docker-compose.yml down
+docker-compose -f docker-compose.lacus.yml down
 ```
 
-### 5. Access Web Interface 🌐
-- **URL**: `http://localhost:7000`
+### 4. Access Web Interface 🌐
+- **AIL Web UI**: [http://localhost:7000](http://localhost:7000)
+- **Lacus API**: [http://localhost:7100](http://localhost:7100)
 - **Default Login**: `ail@ail.test` / `ail`
-- **Dashboard**: Overview of system status and modules
-- **Crawler**: `Navigation → Crawlers → Crawler Splash` for web crawling
 
 ---
 
-## 🕷️ **Web Crawler Usage** (VERIFIED WORKING)
 
-### Submit Crawl Request
-1. **Login** to web interface: `http://localhost:7000`
+## 🕷️ **Web Crawler (Lacus) Usage**
+
+The Lacus crawler is now a **separate, modular service**. You can:
+- Start/stop Lacus independently for development or scaling
+- Run multiple Lacus instances for higher throughput
+- Develop or debug Lacus in isolation
+
+**Typical workflow:**
+1. **Login** to the AIL web interface: [http://localhost:7000](http://localhost:7000)
 2. **Navigate**: `Crawlers → Crawler Splash`
-3. **Enter URL**: Any website (e.g., `https://example.com`)
-4. **Click Submit** → Watch real-time processing in logs
-
-### Monitor Crawling Activity
-```powershell
-# Watch crawler logs in real-time
-docker-compose logs -f ail-app | findstr -i crawler
-
-# Check Lacus service logs  
-docker-compose logs -f lacus
-
-# Monitor work queue
-docker exec -it ail-framework-redis-work-1 redis-cli -p 6381 monitor
-```
-
-### Crawler Status Verification
-```powershell
-# Check module status
-curl http://localhost:7000/api/v1/modules | jq
-
-# Verify Redis work queue
-docker exec -it ail-framework-redis-work-1 redis-cli -p 6381 keys "*"
-
-# Check Kvrocks connection
-docker exec -it ail-framework-kvrocks-1 redis-cli -h kvrocks -p 6383 ping
-```
+3. **Enter URL** and submit
+4. **Monitor logs** using Makefile/scripts or Docker Compose as above
 
 ---
 
-## 🔧 Configuration Files
-
-### Core Configuration
-- **Main Config**: `configs/docker/core.cfg` (container-optimized)
-- **Kvrocks Config**: `kvrocks.conf` (database settings)
-- **Docker Compose**: `docker-compose.yml` (service orchestration)
-- **Container Startup**: `docker-entrypoint.sh` (initialization script)
-
-### Key Configuration Changes for Docker
-```ini
-# Flask server accessible from host
-[Flask]
 host = 0.0.0.0
-port = 7000
-
-# Redis services point to containers
-[Redis_Cache]
 host = redis-cache
-port = 6379
-
-# Kvrocks persistent storage
-[Kvrocks_DB] 
 host = kvrocks
-port = 6383
-```
+
+## 🔧 Configuration Overview
+
+- **AIL Main Config:** `configs/docker/core.cfg` (container-optimized)
+- **Lacus Config:** `configs/lacus/docker.generic.json`
+- **Kvrocks Config:** `kvrocks.conf` (database settings)
+- **Docker Compose:** `docker-compose.yml` (AIL), `docker-compose.lacus.yml` (Lacus)
+- **Container Startup:** `docker-entrypoint.sh` (initialization script)
 
 ---
+
 
 ## 💾 Data Persistence
 
 All important data is persisted outside containers:
 
-| Data Type | Host Path | Container Path | Purpose |
-|-----------|-----------|----------------|---------|
-| Pastes | `./data/pastes` | `/opt/ail/PASTES` | Analyzed content |
-| Screenshots | `./data/screenshots` | `/opt/ail/CRAWLED_SCREENSHOT` | Web captures |
-| Images | `./data/images` | `/opt/ail/IMAGES` | Extracted images |
-| Logs | `./data/logs` | `/opt/ail/logs` | Application logs |
-| Kvrocks DB | `./data/kvrocks` | `/opt/kvrocks/data` | Persistent database |
+| Data Type   | Host Path           | Container Path           | Purpose            |
+|-------------|---------------------|--------------------------|--------------------|
+| Pastes      | `./data/pastes`     | `/opt/ail/PASTES`        | Analyzed content   |
+| Screenshots | `./data/screenshots`| `/opt/ail/CRAWLED_SCREENSHOT` | Web captures |
+| Images      | `./data/images`     | `/opt/ail/IMAGES`        | Extracted images   |
+| Logs        | `./data/logs`       | `/opt/ail/logs`          | Application logs   |
+| Kvrocks DB  | `./data/kvrocks`    | `/opt/kvrocks/data`      | Persistent database|
+| Lacus Data  | `./data/lacus`      | `/opt/lacus/data`        | Crawler data       |
 
 ---
+
 
 ## 📊 Monitoring & Troubleshooting
 
-### Health Checks
-```powershell
-# Quick system status
-docker-compose ps
-curl http://localhost:7000/api/v1/health
-
-# Database connectivity
-docker exec -it ail-framework-redis-cache-1 redis-cli ping
-docker exec -it ail-framework-kvrocks-1 redis-cli -h kvrocks -p 6383 ping
-
-# Module status
-curl http://localhost:7000/api/v1/modules
-```
-
-### Common Issues & Solutions
-
-**❌ "AIL not responding"**
-```powershell
-# Check if container is running
-docker-compose ps ail-app
-
-# View startup logs
-docker-compose logs ail-app
-
-# Restart if needed
-docker-compose restart ail-app
-```
-
-**❌ "Crawler not working"**
-```powershell
-# Verify Lacus service
-curl http://localhost:7100/
-
-# Check crawler module
-docker-compose logs ail-app | findstr -i "crawler.py"
-
-# Verify Redis work queue
-docker exec -it ail-framework-redis-work-1 redis-cli -p 6381 keys "*queue*"
-```
-
-**❌ "Database connection errors"**
-```powershell
-# Check Redis services
-docker-compose logs redis-cache redis-log redis-work
-
-# Test Kvrocks connectivity  
-docker exec -it ail-framework-kvrocks-1 redis-cli -h kvrocks -p 6383 info
-```
-
-### Log Locations
-```powershell
-# Application logs
-docker-compose logs ail-app
-
-# Individual module logs (inside container)
-docker exec -it ail-framework-ail-app-1 ls /opt/ail/logs/
-
-# Specific module log
-docker exec -it ail-framework-ail-app-1 tail -f /opt/ail/logs/crawler.log
-```
+See [`docs/docker.md`](docs/docker.md) for detailed troubleshooting, health checks, and advanced monitoring tips.
 
 ---
+
 
 ## 🔐 Security Configuration
 
-### Default Users
 - **Admin User**: `ail@ail.test` / `ail` (auto-created)
 - **API Access**: Available at `/api/v1/` endpoints
 
-### Production Security Checklist
-- [ ] Change default passwords
-- [ ] Configure SSL/TLS certificates
-- [ ] Set up proper firewall rules
-- [ ] Configure authentication backend
-- [ ] Enable audit logging
+See [`docs/docker.md`](docs/docker.md) for production security checklist and best practices.
 
 ---
 
-## 🚢 Deployment Options
 
-### Local Development ✅ (Current Setup)
-- All services on localhost
-- Data persisted to `./data/` directories  
-- Direct container access for debugging
+## 🚢 Deployment & Scaling
 
-### Azure Container Apps 🌐 (Ready for Deployment)
-- Replace Redis services with **Azure Cache for Redis**
-- Use **Azure Container Registry** for images
-- Configure **Azure Files** for persistent storage
-- Set up **Azure Application Gateway** for SSL termination
+- **Local Development:** All services run on localhost, with data persisted to `./data/` directories.
+- **Lacus Separation:** The Lacus crawler stack is fully modular—start/stop/scale it independently for development, testing, or production scaling.
+- **Production Scaling:**
+  - Run multiple AIL or Lacus instances behind a load balancer
+  - Use managed Redis/Kvrocks/Valkey for high availability
+  - Store large files in object storage (Azure Blob, AWS S3, etc.)
+  - Integrate with monitoring tools (Prometheus, Azure Monitor, etc.)
 
-### Production Scaling 📈
-- **Horizontal**: Multiple AIL app instances behind load balancer
-- **Database**: Separate Redis cluster + managed Kvrocks
-- **Storage**: Object storage (Azure Blob/AWS S3) for large files
-- **Monitoring**: Azure Monitor/Prometheus integration
+See [`docs/docker.md`](docs/docker.md) for cloud deployment, advanced scaling, and infrastructure options.
 
 ---
 
-## 🧹 **File Cleanup Recommendations**
 
-### Obsolete Files (Safe to Remove)
-```powershell
-# Remove conflicting host-specific config
-Remove-Item core.cfg
+## 🧹 File Cleanup & Optional Components
 
-# Remove obsolete virtual environment installer  
-Remove-Item install_virtualenv.sh
-
-# Optional: Remove unused development helper
-Remove-Item dev-helper.sh
-```
-
-### Optional Components
-- **`misp/`** directory: MISP threat intelligence integration (keep if needed)
-- **`.dockerignore`**: Review exclusions, may be too aggressive
+See [`docs/docker.md`](docs/docker.md) for file cleanup recommendations and optional component details.
 
 ---
+
 
 ## 📈 Performance Tuning
 
-### Resource Allocation
-```yaml
-# docker-compose.yml additions for production
-services:
-  ail-app:
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-          cpus: 2.0
-        reservations:
-          memory: 2G
-          cpus: 1.0
-```
-
-### Database Optimization
-```ini
-# kvrocks.conf tuning
-max-db-size 20gb
-max-memory-usage 8gb
-workers 4
-```
+See [`docs/docker.md`](docs/docker.md) for resource allocation, database optimization, and performance tuning tips.
 
 ---
 
-## 🆘 Support & Documentation
 
 ## 🆘 Support & Documentation
 
-### Getting Help
-- **Troubleshooting Guide**: See `docs/troubleshooting.md` for detailed problem resolution
-- **Crawler Architecture**: See `docs/crawler-architecture.md` for technical implementation details  
-- **Docker Setup Guide**: See `docs/docker.md` for comprehensive setup instructions
-- **AIL Documentation**: [Official AIL Docs](https://ail-project.github.io/ail-framework/)
-- **Docker Issues**: Check logs with `docker-compose logs [service]`
-- **Crawler Problems**: Verify Lacus at `http://localhost:7100`
+- **Full Docker Setup Guide:** [`docs/docker.md`](docs/docker.md)
+- **Troubleshooting:** [`docs/troubleshooting.md`](docs/troubleshooting.md)
+- **Crawler Architecture:** [`docs/crawler-architecture.md`](docs/crawler-architecture.md)
+- **Official AIL Documentation:** [https://ail-project.github.io/ail-framework/](https://ail-project.github.io/ail-framework/)
 
-### Useful Commands
-```powershell
-# Complete system restart
-docker-compose down && docker-compose up -d --build
-
-# Reset all data (WARNING: Destructive)
-docker-compose down -v && Remove-Item -Recurse -Force data
-
-# Export/Import configurations
-docker exec ail-framework-ail-app-1 tar -czf /tmp/ail-config.tar.gz /opt/ail/configs
-```
+For Docker issues, check logs with `make logs` or the orchestration scripts. For crawler problems, verify Lacus at [http://localhost:7100](http://localhost:7100).
 
 ---
 
-**🎉 SUCCESS**: This Docker setup provides a fully functional AIL Framework with verified web crawling capabilities, ready for development and deployment!
+**🎉 SUCCESS:** This unified Docker setup provides a fully functional, modular, and scalable AIL Framework with verified web crawling capabilities. Start here, and see [`docs/docker.md`](docs/docker.md) for everything else!

--- a/bin/lib/objects/Domains.py
+++ b/bin/lib/objects/Domains.py
@@ -703,7 +703,7 @@ def update_vanity_cluster(domain):
     vanity = get_domain_vanity(domain, len_vanity=4)
     add = r_crawler.sadd(f'vanity:4:{vanity}', domain)
     if add == 1:
-        r_crawler.zadd('vanity:onion:4', {vanity: 1}, incr=True)
+        r_crawler.zincrby('vanity:onion:4', 1, vanity)
 
 def _rebuild_vanity_clusters():
     for vanity in r_crawler.zrange('vanity:onion:4', 0, -1):

--- a/docker-compose.lacus.yml
+++ b/docker-compose.lacus.yml
@@ -1,0 +1,56 @@
+name: lacus
+services:
+  # Tor proxy for Lacus .onion crawling
+  tor_proxy:
+    image: osminogin/tor-simple:latest
+    networks:
+      - lacus-net
+    restart: unless-stopped
+
+  # Valkey for Lacus (Redis alternative)
+  valkey:
+    image: valkey/valkey:8.0
+    command: ["valkey-server", "--port", "6385"]
+    volumes:
+      - valkey_data:/data
+    networks:
+      - lacus-net
+    restart: unless-stopped
+  # Lacus crawler service
+  lacus:
+    build:
+      context: .
+      dockerfile: Dockerfile.lacus
+    environment:
+      LACUS_HOME: /opt/lacus
+      PYTHONPATH: /opt/lacus
+      NODE_OPTIONS: --max_old_space_size=4096
+    ports:
+      - "7100:7100"    
+    volumes:
+      - ./data/lacus:/opt/lacus/data
+      - ./data/logs:/opt/lacus/logs
+      - ./configs/lacus/docker.generic.json:/opt/lacus/config/generic.json
+    networks:
+      - lacus-net
+      - ail-net  # Connect to AIL network for communication
+    depends_on:
+      - valkey
+      - tor_proxy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 6G
+        reservations:
+          memory: 2G
+
+volumes:
+  valkey_data:
+
+networks:
+  lacus-net:
+    driver: bridge
+  ail-net:
+    external: true
+    name: ail-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+name: ail
 services:
   redis-cache:
     image: redis:6-alpine
@@ -35,52 +36,14 @@ services:
     networks:
       - ail-net
     restart: unless-stopped
-
-  # Tor proxy for Lacus .onion crawling
-  tor_proxy:
-    image: osminogin/tor-simple:latest
-    networks:
-      - ail-net
-    restart: unless-stopped
-
-  # Valkey for Lacus (Redis alternative)
-  valkey:
-    image: valkey/valkey:8.0
-    command: ["valkey-server", "--port", "6385"]
-    volumes:
-      - valkey_data:/data
-    networks:
-      - ail-net
-    restart: unless-stopped
-
-  # Lacus crawler service
-  lacus:
-    build:
-      context: .
-      dockerfile: Dockerfile.lacus
-    environment:
-      LACUS_HOME: /opt/lacus
-      PYTHONPATH: /opt/lacus
-    ports:
-      - "7100:7100"    
-    volumes:
-      - ./data/lacus:/opt/lacus/data
-      - ./data/logs:/opt/lacus/logs
-      - ./configs/lacus/docker.generic.json:/opt/lacus/config/generic.json
-    networks:
-      - ail-net
-    depends_on:
-      - valkey
-      - tor_proxy
-    restart: no  
   init-lacus-url:
     image: redis:6-alpine
     depends_on:
       - kvrocks
-    entrypoint: ["sh", "-c", "redis-cli -h kvrocks -p 6383 HSET crawler:lacus url http://lacus:7100"]
+    entrypoint: ["sh", "-c", "redis-cli -h kvrocks -p 6383 HSET crawler:lacus url http://lacus-lacus-1:7100"]
     networks:
-      - ail-net
-    restart: "no"
+      - ail-net    
+    restart: no
 
   ail-app:
     build:
@@ -92,6 +55,7 @@ services:
       AIL_HOME: /opt/ail
       AIL_BIN: /opt/ail/bin
       AIL_FLASK: /opt/ail/var/www
+      MISP_KEY: ${MISP_KEY}
     ports:
       - "7000:7000"
     volumes:
@@ -102,7 +66,7 @@ services:
       - ./data/blooms:/opt/ail/Blooms
       - ./data/hashs:/opt/ail/HASHS
       - ./configs:/opt/ail/configs
-      - ./bin:/opt/ail/bin
+      - ./bin:/opt/ail/bin    
     networks:
       - ail-net
     depends_on:
@@ -110,15 +74,13 @@ services:
       - redis-log
       - redis-work
       - kvrocks
-      - lacus
-    restart: no
+    restart: unless-stopped
 
 volumes:
   redis_cache_data:
   redis_log_data:
   redis_work_data:
-  valkey_data:
 
 networks:
   ail-net:
-    driver: bridge
+    external: true

--- a/scripts/start-all.ps1
+++ b/scripts/start-all.ps1
@@ -1,0 +1,122 @@
+# AIL Framework with Lacus - PowerShell Startup Script
+
+param(
+    [Parameter(Position=0)]
+    [string]$Command = "up",
+    
+    [Parameter(Position=1)]
+    [string]$Service = ""
+)
+
+$LacusCompose = "docker-compose.lacus.yml"
+$MainCompose = "docker-compose.yml"
+
+function Show-Usage {
+    Write-Host "Usage: .\start-all.ps1 {up|down|restart|logs [service]|status|lacus-only [action]|ail-only [action]}"
+    Write-Host ""
+    Write-Host "Commands:"
+    Write-Host "  up           - Start all services (Lacus first, then AIL)"
+    Write-Host "  down         - Stop all services"
+    Write-Host "  restart      - Restart all services"
+    Write-Host "  logs [svc]   - Show logs for a specific service or list available services"
+    Write-Host "  status       - Show status of all services"
+    Write-Host "  lacus-only   - Manage only Lacus services"
+    Write-Host "  ail-only     - Manage only AIL services"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  .\start-all.ps1 up                    # Start everything"
+    Write-Host "  .\start-all.ps1 logs lacus           # Show Lacus logs"
+    Write-Host "  .\start-all.ps1 lacus-only down      # Stop only Lacus"
+    Write-Host "  .\start-all.ps1 ail-only restart     # Restart only AIL"
+}
+
+switch ($Command.ToLower()) {
+    "up" {
+        Write-Host "Starting AIL Framework with Lacus..." -ForegroundColor Green
+        Write-Host "Creating external network 'ail-net' if it doesn't exist..."
+        try {
+            docker network create ail-net --driver bridge 2>$null
+        } catch {
+            # Network likely already exists
+        }
+        Write-Host "Starting Lacus services..."
+        docker-compose -f $LacusCompose up -d --remove-orphans
+        
+        Write-Host "Waiting for Lacus to be ready..."
+        Start-Sleep -Seconds 10
+        
+        Write-Host "Starting AIL services..."
+        docker-compose -f $MainCompose up -d --remove-orphans
+        
+        Write-Host "All services started successfully!" -ForegroundColor Green
+        Write-Host "AIL Web Interface: http://localhost:7000" -ForegroundColor Cyan
+        Write-Host "Lacus API: http://localhost:7100" -ForegroundColor Cyan
+    }
+    "down" {
+        Write-Host "Stopping AIL Framework and Lacus..." -ForegroundColor Yellow
+        docker-compose -f $MainCompose down --remove-orphans
+        docker-compose -f $LacusCompose down --remove-orphans
+        Write-Host "All services stopped." -ForegroundColor Green
+    }
+    
+    "restart" {
+        Write-Host "Restarting AIL Framework and Lacus..." -ForegroundColor Yellow
+        & $MyInvocation.MyCommand.Path down
+        Start-Sleep -Seconds 5
+        & $MyInvocation.MyCommand.Path up
+    }
+    
+    "logs" {
+        if ($Service) {
+            $mainServices = docker-compose -f $MainCompose ps --services
+            $lacusServices = docker-compose -f $LacusCompose ps --services
+            
+            if ($mainServices -contains $Service) {
+                docker-compose -f $MainCompose logs -f $Service
+            } elseif ($lacusServices -contains $Service) {
+                docker-compose -f $LacusCompose logs -f $Service
+            } else {
+                Write-Host "Service '$Service' not found." -ForegroundColor Red
+                exit 1
+            }
+        } else {
+            Write-Host "Available services:" -ForegroundColor Cyan
+            Write-Host "Main services:" -ForegroundColor Yellow
+            docker-compose -f $MainCompose ps --services
+            Write-Host "Lacus services:" -ForegroundColor Yellow
+            docker-compose -f $LacusCompose ps --services
+        }
+    }
+    
+    "status" {
+        Write-Host "AIL Services Status:" -ForegroundColor Cyan
+        docker-compose -f $MainCompose ps
+        Write-Host ""
+        Write-Host "Lacus Services Status:" -ForegroundColor Cyan
+        docker-compose -f $LacusCompose ps
+    }
+    "lacus-only" {
+        $Action = if ($Service) { $Service } else { "up" }
+        Write-Host "Managing Lacus services only: $Action" -ForegroundColor Yellow
+        if ($Action -eq "up" -or $Action -eq "down") {
+            docker-compose -f $LacusCompose $Action --remove-orphans
+        } else {
+            docker-compose -f $LacusCompose $Action
+        }
+    }
+    
+    "ail-only" {
+        $Action = if ($Service) { $Service } else { "up" }
+        Write-Host "Managing AIL services only: $Action" -ForegroundColor Yellow
+        if ($Action -eq "up" -or $Action -eq "down") {
+            docker-compose -f $MainCompose $Action --remove-orphans
+        } else {
+            docker-compose -f $MainCompose $Action
+        }
+    }
+    
+    default {
+        Show-Usage
+        exit 1
+    }
+}

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# AIL Framework with Lacus - Startup Script
+
+set -e
+
+COMMAND=${1:-up}
+LACUS_COMPOSE="docker-compose.lacus.yml"
+MAIN_COMPOSE="docker-compose.yml"
+
+case "$COMMAND" in
+    up)
+        echo "Starting AIL Framework with Lacus..."
+        echo "Creating external network 'ail-net' if it doesn't exist..."
+        docker network create ail-net --driver bridge || true
+        
+        echo "Starting Lacus services..."
+        docker-compose -f $LACUS_COMPOSE up -d
+        
+        echo "Waiting for Lacus to be ready..."
+        sleep 10
+        
+        echo "Starting AIL services..."
+        docker-compose -f $MAIN_COMPOSE up -d
+        
+        echo "All services started successfully!"
+        echo "AIL Web Interface: http://localhost:7000"
+        echo "Lacus API: http://localhost:7100"
+        ;;
+    
+    down)
+        echo "Stopping AIL Framework and Lacus..."
+        docker-compose -f $MAIN_COMPOSE down
+        docker-compose -f $LACUS_COMPOSE down
+        echo "All services stopped."
+        ;;
+    
+    restart)
+        echo "Restarting AIL Framework and Lacus..."
+        $0 down
+        sleep 5
+        $0 up
+        ;;
+    
+    logs)
+        SERVICE=${2:-}
+        if [ -n "$SERVICE" ]; then
+            if docker-compose -f $MAIN_COMPOSE ps | grep -q "$SERVICE"; then
+                docker-compose -f $MAIN_COMPOSE logs -f "$SERVICE"
+            elif docker-compose -f $LACUS_COMPOSE ps | grep -q "$SERVICE"; then
+                docker-compose -f $LACUS_COMPOSE logs -f "$SERVICE"
+            else
+                echo "Service '$SERVICE' not found."
+                exit 1
+            fi
+        else
+            echo "Available services:"
+            echo "Main services:"
+            docker-compose -f $MAIN_COMPOSE ps --services
+            echo "Lacus services:"
+            docker-compose -f $LACUS_COMPOSE ps --services
+        fi
+        ;;
+    
+    status)
+        echo "AIL Services Status:"
+        docker-compose -f $MAIN_COMPOSE ps
+        echo ""
+        echo "Lacus Services Status:"
+        docker-compose -f $LACUS_COMPOSE ps
+        ;;
+    
+    lacus-only)
+        ACTION=${2:-up}
+        echo "Managing Lacus services only: $ACTION"
+        docker-compose -f $LACUS_COMPOSE $ACTION
+        ;;
+    
+    ail-only)
+        ACTION=${2:-up}
+        echo "Managing AIL services only: $ACTION"
+        docker-compose -f $MAIN_COMPOSE $ACTION
+        ;;
+    
+    *)
+        echo "Usage: $0 {up|down|restart|logs [service]|status|lacus-only [action]|ail-only [action]}"
+        echo ""
+        echo "Commands:"
+        echo "  up           - Start all services (Lacus first, then AIL)"
+        echo "  down         - Stop all services"
+        echo "  restart      - Restart all services"
+        echo "  logs [svc]   - Show logs for a specific service or list available services"
+        echo "  status       - Show status of all services"
+        echo "  lacus-only   - Manage only Lacus services"
+        echo "  ail-only     - Manage only AIL services"
+        echo ""
+        echo "Examples:"
+        echo "  $0 up                    # Start everything"
+        echo "  $0 logs lacus           # Show Lacus logs"
+        echo "  $0 lacus-only down      # Stop only Lacus"
+        echo "  $0 ail-only restart     # Restart only AIL"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
- Consolidate all Docker-based orchestration and documentation into a single, unified workflow for the AIL Framework and Lacus crawler.
- Supersede legacy orchestration scripts (`ail-lacus.ps1`, `ail-lacus.sh`) with standardized, cross-platform scripts (`scripts/start-all.ps1`, `scripts/start-all.sh`).
- Update and unify `README-Docker.md` as the high-level entry point for all Docker usage, including:
  - Clear instructions for using the new Makefile targets and orchestration scripts.
  - Explicit documentation of the modular Lacus stack and its independent scaling/management.
  - Removal of redundant or outdated details now covered in the unified workflow.
  - Pointers to `docs/docker.md` for advanced usage, troubleshooting, and architecture.
- Mark `README-Lacus-Separation.md` and legacy orchestration scripts as superseded.
- Ensure all references, naming, and usage examples are consistent across documentation and scripts.
- Test and verify that the new orchestration scripts successfully stop and start all services.
- Prepare the codebase for easier onboarding, maintenance, and future scaling.

BREAKING CHANGE: Users should now use the new Makefile targets or scripts in `scripts/` for all Docker orchestration. Legacy scripts and split documentation are deprecated.